### PR TITLE
Adds transitive dependencies

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/snyk/snyk-code-review-exercise/api"
@@ -32,8 +34,10 @@ func TestPackageHandler(t *testing.T) {
 	assert.Equal(t, "react", data.Name)
 	assert.Equal(t, "16.13.0", data.Version)
 
-	assert.Len(t, data.Dependencies, 3)
-	assert.Equal(t, "1.4.0", data.Dependencies["loose-envify"])
-	assert.Equal(t, "4.1.1", data.Dependencies["object-assign"])
-	assert.Equal(t, "15.7.2", data.Dependencies["prop-types"])
+	fixture, err := os.Open(filepath.Join("testdata", "react-16.13.0.json"))
+	require.Nil(t, err)
+	var fixtureObj api.NpmPackageVersion
+	require.Nil(t, json.NewDecoder(fixture).Decode(&fixtureObj))
+
+	assert.Equal(t, fixtureObj, data)
 }

--- a/api/testdata/react-16.13.0.json
+++ b/api/testdata/react-16.13.0.json
@@ -1,0 +1,49 @@
+{
+  "name": "react",
+  "version": "16.13.0",
+  "dependencies": {
+    "loose-envify": {
+      "name": "loose-envify",
+      "version": "1.4.0",
+      "dependencies": {
+        "js-tokens": {
+          "name": "js-tokens",
+          "version": "4.0.0",
+          "dependencies": {}
+        }
+      }
+    },
+    "object-assign": {
+      "name": "object-assign",
+      "version": "4.1.1",
+      "dependencies": {}
+    },
+    "prop-types": {
+      "name": "prop-types",
+      "version": "15.7.2",
+      "dependencies": {
+        "loose-envify": {
+          "name": "loose-envify",
+          "version": "1.4.0",
+          "dependencies": {
+            "js-tokens": {
+              "name": "js-tokens",
+              "version": "4.0.0",
+              "dependencies": {}
+            }
+          }
+        },
+        "object-assign": {
+          "name": "object-assign",
+          "version": "4.1.1",
+          "dependencies": {}
+        },
+        "react-is": {
+          "name": "react-is",
+          "version": "16.13.1",
+          "dependencies": {}
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
(copied from https://github.com/snyk/snyk-code-review-exercise/pull/6 so i could just leave real review comments)

In order to extend our vulnerability scanning feature to support child dependencies for [npm packages](https://docs.npmjs.com/cli/v6/configuring-npm/package-json) as described in https://github.com/snyk/snyk-code-review-exercise/issues/5 , this pull request updates the package service to return all nested dependencies on the internal /package endpoint for consumption by vulnerability service instead of just returning the versions for the first level.

It supports a GET request to the `/package/:name/:version` endpoint and will return a JSON structure representing the full tree of dependencies. We will always return the latest matching version of a package supported to mimic the behavior of a fresh `npm install`.

#### Testing

It can be tested locally by making a request for a package with sub-dependencies e.g. `react@16.13.0`

```
curl -s http://localhost:3000/package/react/16.13.0 | jq .
```

#### Related Ticket

https://github.com/snyk/snyk-code-review-exercise/issues/5